### PR TITLE
Add once a week test

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -1,6 +1,6 @@
 on:
   schedule:
-  - cron: "0 0 * * *"
+  - cron: "0 0 * * 0"
   
 jobs:
   test:


### PR DESCRIPTION
Use Github actions to run the test suite once a day.

At ~11 minute run time and $0.008 a minute this will cost ~$32 a year. The run time will be increasing, but it should remain relatively cheap, even on the expensive yet convenient GH action runners.