### PR TITLE
feat: 🎸 add generate examples script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage/
 test.ts
 docs/
 .env
+examples/

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The URLs of the services under test can be set with environment variables. Look 
 - `yarn semantic-release` runs semantic release to calculate version numbers based on the nature of changes since the last version (used in CI pipelines)
 - `yarn lint` runs the linter on all .ts(x) and .js(x) files and outputs all errors
 - `yarn format` runs prettier on all .ts(x) and .js(x) files and formats them according to the project standards
+- `yarn generate-examples` modifies SDK src files to generate examples. These will need to be copied to the examples repository
 
 ## Notes
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "semantic-release": "semantic-release",
     "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
     "format": "cross-env prettier-eslint $PWD\"/src/**/*.{ts,tsx,js,jsx,json,css,md}\" --write",
-    "dedupe:lock": "npx yarn-deduplicate yarn.lock"
+    "dedupe:lock": "npx yarn-deduplicate yarn.lock",
+    "generate-examples": "ts-node ./scripts/generate-examples.ts"
   },
   "devDependencies": {
     "@babel/plugin-transform-modules-commonjs": "^7.20.11",

--- a/scripts/generate-examples.ts
+++ b/scripts/generate-examples.ts
@@ -1,0 +1,82 @@
+import { writeFileSync } from 'fs';
+import * as path from 'path';
+import { Project, SyntaxKind } from 'ts-morph';
+
+const project = new Project({
+  tsConfigFilePath: './tsconfig.json',
+  skipAddingFilesFromTsConfig: true,
+});
+const assertImportSpecifier = 'assert';
+
+const outputPath = './examples';
+
+const excludePaths = ['settlements/util.ts'];
+
+project.addSourceFilesAtPaths('./src/sdk/**/*.ts');
+
+// Get all the source files
+const sourceFiles = project.getSourceFiles();
+// Loop through all the files
+sourceFiles.forEach((sourceFile) => {
+  // Determine the path of the new file based on the path of the source file
+  const relativePath = path.relative(path.resolve('src/sdk'), sourceFile.getFilePath());
+
+  if (excludePaths.includes(relativePath)) {
+    return;
+  }
+
+  const newPath = path.resolve(outputPath, relativePath);
+
+  // Create a new source file for the example
+  const newFile = project.createSourceFile(newPath, sourceFile.getFullText(), { overwrite: true });
+
+  // Remove import declaration of 'assert'
+  newFile.getImportDeclarations().forEach((importDeclaration) => {
+    if (importDeclaration.getModuleSpecifierValue() === assertImportSpecifier) {
+      importDeclaration.remove();
+    }
+  });
+
+  // Find all CallExpressions
+  const callExpressions = newFile.getDescendantsOfKind(SyntaxKind.CallExpression);
+
+  // Filter out the assert calls
+  const assertCalls = callExpressions.filter((call) => {
+    const expression = call.getExpression();
+
+    return (
+      expression.getKind() === SyntaxKind.Identifier &&
+      expression.getText() === assertImportSpecifier
+    );
+  });
+
+  // Remove assert calls as they clutter the examples
+  assertCalls.forEach((assertCall) => {
+    const parentStatement = assertCall.getFirstAncestorByKind(SyntaxKind.ExpressionStatement);
+    if (parentStatement) {
+      parentStatement.remove();
+    }
+  });
+
+  // Organize imports and format the new file before saving
+  newFile.organizeImports();
+  newFile.formatText();
+});
+
+// Save changes to disk
+project.save();
+
+// Write a file that will allow for config
+const configPath = path.join(outputPath, 'config.ts');
+
+const exampleConfig = `export const config = {
+  nodeUrl: process.env.NODE_URL || 'ws://localhost:9944',
+  graphqlUrl: process.env.GRAPHQL_URL || 'http://localhost:3001',
+};`;
+
+export const config = {
+  nodeUrl: process.env.NODE_URL || 'ws://localhost:9944',
+  graphqlUrl: process.env.GRAPHQL_URL || 'http://localhost:3001',
+};
+
+writeFileSync(configPath, exampleConfig);

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,7 +13,7 @@ const graphqlUrl = process.env.GRAPHQL_URL || 'http://localhost:3001';
  */
 const deleteUsedKeys = !!process.env.DELETE_USED_KEYS || false;
 
-export const env = {
+export const config = {
   nodeUrl,
   restApi,
   vaultUrl,

--- a/src/helpers/admin-setup.ts
+++ b/src/helpers/admin-setup.ts
@@ -3,15 +3,15 @@ import 'tsconfig-paths/register'; // (Solution from)[https://github.com/facebook
 import { RestClient } from '~/rest';
 import { VaultClient } from '~/vault';
 
-import { env } from '../environment';
+import { config } from '../config';
 
 const maxWorkersSupported = 8;
 
 const initialPolyx = 100000000;
 
 export default async (): Promise<void> => {
-  const vaultClient = new VaultClient(env.vaultUrl, env.vaultTransitPath, env.vaultToken);
-  const restClient = new RestClient(env.restApi);
+  const vaultClient = new VaultClient(config.vaultUrl, config.vaultTransitPath, config.vaultToken);
+  const restClient = new RestClient(config.restApi);
 
   const adminSigners = [...Array(maxWorkersSupported)].map((_, index) => `${index + 1}-admin`);
 

--- a/src/helpers/factory.ts
+++ b/src/helpers/factory.ts
@@ -1,7 +1,7 @@
 import { LocalSigningManager } from '@polymeshassociation/local-signing-manager';
 import { Polymesh } from '@polymeshassociation/polymesh-sdk';
 
-import { env } from '~/environment';
+import { config } from '~/config';
 import { TestFactoryOpts } from '~/helpers/types';
 import { RestClient } from '~/rest';
 import { Identity } from '~/rest/identities';
@@ -11,7 +11,7 @@ import { VaultClient } from '~/vault';
 
 const nonceLength = 9;
 const startingPolyx = 100000;
-const { nodeUrl, vaultUrl, vaultToken, vaultTransitPath } = env;
+const { nodeUrl, vaultUrl, vaultToken, vaultTransitPath } = config;
 
 export class TestFactory {
   public nonce: string;
@@ -27,7 +27,7 @@ export class TestFactory {
     const { handles: signers } = opts;
 
     const middlewareV2 = {
-      link: env.graphqlUrl,
+      link: config.graphqlUrl,
       key: '',
     };
 
@@ -143,7 +143,7 @@ export class TestFactory {
   }
 
   private async cleanupIdentities(): Promise<void> {
-    if (env.deleteUsedKeys) {
+    if (config.deleteUsedKeys) {
       await Promise.all(
         Object.keys(this.handleToIdentity).map(async (handle) => {
           const keyName = this.prefixNonce(handle);
@@ -157,7 +157,7 @@ export class TestFactory {
 
   private constructor(public readonly polymeshSdk: Polymesh) {
     this.nonce = randomNonce(nonceLength);
-    this.restClient = new RestClient(env.restApi);
+    this.restClient = new RestClient(config.restApi);
     this.vaultClient = new VaultClient(vaultUrl, vaultTransitPath, vaultToken);
   }
 }

--- a/src/sdk/assets/addAssetAgent.ts
+++ b/src/sdk/assets/addAssetAgent.ts
@@ -13,7 +13,9 @@ export const addAssetAgent = async (
   ticker: string
 ): Promise<void> => {
   const signingIdentity = await sdk.getSigningIdentity();
-  assert(signingIdentity);
+  if (!signingIdentity) {
+    throw new Error('The SDK does not have a signing identity');
+  }
 
   const target = await sdk.identities.getIdentity({
     did: targetDid,

--- a/src/sdk/assets/manageCAA.ts
+++ b/src/sdk/assets/manageCAA.ts
@@ -17,7 +17,9 @@ export const manageCAA = async (
     sdk.getSigningIdentity(),
     sdk.identities.getIdentity({ did: targetDid }),
   ]);
-  assert(identity);
+  if (!identity) {
+    throw new Error('The SDK must have a signing identity');
+  }
 
   const asset = await sdk.assets.getAsset({ ticker });
 
@@ -40,7 +42,9 @@ export const manageCAA = async (
 
   const pendingAuthorizations = await target.authorizations.getReceived({ includeExpired: false });
   const becomeCAAAuth = pendingAuthorizations.find(({ authId }) => authId.eq(authRequest.authId));
-  assert(becomeCAAAuth, 'the authorization should be findable by the target');
+  if (!becomeCAAAuth) {
+    throw new Error('The CAA auth should be findable');
+  }
 
   const { account: targetAccount } = await target.getPrimaryAccount();
 

--- a/src/sdk/assets/manageCheckpoints.ts
+++ b/src/sdk/assets/manageCheckpoints.ts
@@ -1,6 +1,7 @@
 import { BigNumber, Polymesh } from '@polymeshassociation/polymesh-sdk';
 import { CalendarUnit } from '@polymeshassociation/polymesh-sdk/types';
 import assert from 'node:assert';
+import { sign } from 'node:crypto';
 
 /*
   This script showcases Checkpoints related functionality. It:
@@ -15,7 +16,9 @@ import assert from 'node:assert';
 */
 export const manageCheckpoints = async (sdk: Polymesh, ticker: string): Promise<void> => {
   const signingIdentity = await sdk.getSigningIdentity();
-  assert(signingIdentity);
+  if (!signingIdentity) {
+    throw new Error('The SDK must have a signing identity');
+  }
 
   // The signing identity should be an agent of the Asset and have appropriate permission
   const asset = await sdk.assets.getAsset({ ticker });

--- a/src/sdk/assets/manageDistributions.ts
+++ b/src/sdk/assets/manageDistributions.ts
@@ -21,7 +21,9 @@ export const manageDistributions = async (
   distributionTicker: string
 ): Promise<void> => {
   const signingIdentity = await sdk.getSigningIdentity();
-  assert(signingIdentity);
+  if (!signingIdentity) {
+    throw new Error('the SDK must have a signing identity');
+  }
 
   const alice = await sdk.identities.getIdentity({ did: wellKnown.alice.did });
 

--- a/src/sdk/assets/manageMetadata.ts
+++ b/src/sdk/assets/manageMetadata.ts
@@ -19,7 +19,9 @@ import assert from 'node:assert';
 */
 export const manageMetadata = async (sdk: Polymesh, ticker: string): Promise<void> => {
   const identity = await sdk.getSigningIdentity();
-  assert(identity);
+  if (!identity) {
+    throw new Error('the SDK must have an identity');
+  }
 
   const asset = await sdk.assets.getAsset({ ticker });
 

--- a/src/sdk/assets/tickerReservation.ts
+++ b/src/sdk/assets/tickerReservation.ts
@@ -10,7 +10,9 @@ import assert from 'assert';
 */
 export const tickerReservation = async (sdk: Polymesh, ticker: string): Promise<void> => {
   const identity = await sdk.getSigningIdentity();
-  assert(identity);
+  if (!identity) {
+    throw new Error('the SDK must have a signing identity');
+  }
 
   const { account: signingAccount } = await identity.getPrimaryAccount();
 

--- a/src/sdk/connect.ts
+++ b/src/sdk/connect.ts
@@ -1,9 +1,9 @@
 import { LocalSigningManager } from '@polymeshassociation/local-signing-manager';
 import { Polymesh } from '@polymeshassociation/polymesh-sdk';
 
-import { env } from '~/environment';
+import { config } from '~/config';
 
-const { nodeUrl } = env;
+const { nodeUrl } = config;
 
 let sdk: Polymesh;
 

--- a/src/sdk/identities/claims.ts
+++ b/src/sdk/identities/claims.ts
@@ -14,7 +14,9 @@ import assert from 'node:assert';
 */
 export const manageClaims = async (sdk: Polymesh, targetDid: string): Promise<void> => {
   const identity = await sdk.getSigningIdentity();
-  assert(identity);
+  if (!identity) {
+    throw new Error('the SDK must have an signing identity');
+  }
 
   const { account: signingAccount } = await identity.getPrimaryAccount();
 

--- a/src/sdk/identities/manageSecondaryKeys.ts
+++ b/src/sdk/identities/manageSecondaryKeys.ts
@@ -11,7 +11,9 @@ import assert from 'node:assert';
 */
 export const manageSecondaryKeys = async (sdk: Polymesh, targetAddress: string): Promise<void> => {
   const identity = await sdk.getSigningIdentity();
-  assert(identity);
+  if (!identity) {
+    throw new Error('the SDK must have a signing identity');
+  }
 
   // Account to invite to join the signing Identity
   const targetAccount = await sdk.accountManagement.getAccount({

--- a/src/sdk/identities/portfolioCustody.ts
+++ b/src/sdk/identities/portfolioCustody.ts
@@ -17,7 +17,9 @@ export const portfolioCustody = async (sdk: Polymesh, custodianDid: string): Pro
   const { account: custodianAccount } = await custodian.getPrimaryAccount();
 
   const identity = await sdk.getSigningIdentity();
-  assert(identity);
+  if (!identity) {
+    throw new Error('the SDK must have a signing identity');
+  }
 
   const createPortfolioTx = await sdk.identities.createPortfolio({ name: 'CUSTODY_PORTFOLIO' });
   const portfolio = await createPortfolioTx.run();

--- a/src/sdk/identities/portfolios.ts
+++ b/src/sdk/identities/portfolios.ts
@@ -15,7 +15,9 @@ import { randomNonce } from '~/util';
 */
 export const managePortfolios = async (sdk: Polymesh, ticker: string): Promise<void> => {
   const signingIdentity = await sdk.getSigningIdentity();
-  assert(signingIdentity);
+  if (!signingIdentity) {
+    throw new Error('the SDK must have a signing identity');
+  }
 
   const asset = await sdk.assets.getAsset({ ticker });
 

--- a/src/sdk/settlements/createSto.ts
+++ b/src/sdk/settlements/createSto.ts
@@ -32,7 +32,9 @@ export const createSto = async (
     sdk.assets.getAsset({ ticker: offeringTicker }),
     sdk.assets.getAsset({ ticker: raisingTicker }),
   ]);
-  assert(identity);
+  if (!identity) {
+    throw new Error('the SDK must have a signing identity');
+  }
 
   // Get the investors portfolio and primary account
   const [investorPortfolio, { account: investorAccount }] = await Promise.all([

--- a/src/sdk/settlements/manageComplianceRequirements.ts
+++ b/src/sdk/settlements/manageComplianceRequirements.ts
@@ -22,7 +22,9 @@ export const manageComplianceRequirements = async (
   ticker: string
 ): Promise<void> => {
   const identity = await sdk.getSigningIdentity();
-  assert(identity);
+  if (!identity) {
+    throw new Error('the SDK must have a signing identity');
+  }
 
   // destructure to reduce `asset.` repetition
   const { compliance } = await sdk.assets.getAsset({ ticker });

--- a/src/sdk/settlements/manageTrustedClaimIssuers.ts
+++ b/src/sdk/settlements/manageTrustedClaimIssuers.ts
@@ -15,7 +15,9 @@ import { wellKnown } from '~/consts';
 */
 export const manageTrustedClaimIssuers = async (sdk: Polymesh, ticker: string): Promise<void> => {
   const identity = await sdk.getSigningIdentity();
-  assert(identity);
+  if (!identity) {
+    throw new Error('the SDK must have a signing identity');
+  }
 
   // destructure to reduce `asset.` repetition
   const { compliance } = await sdk.assets.getAsset({ ticker });

--- a/src/sdk/settlements/tradeAssets.ts
+++ b/src/sdk/settlements/tradeAssets.ts
@@ -38,7 +38,9 @@ export const tradeAssets = async (
     sdk.assets.getAsset({ ticker: bid.ticker }),
     sdk.assets.getAsset({ ticker: ask.ticker }),
   ]);
-  assert(identity);
+  if (!identity) {
+    throw new Error('The SDK must have a signing identity');
+  }
 
   const { account: counterPartyAccount } = await counterParty.getPrimaryAccount();
 
@@ -101,7 +103,9 @@ export const tradeAssets = async (
   const { pending } = await counterParty.getInstructions();
 
   const counterInstruction = pending.find(({ id }) => id.eq(instruction.id));
-  assert(counterInstruction, 'the counter party should have the instruction as pending');
+  if (!counterInstruction) {
+    throw new Error('the counter party should have the instruction as pending');
+  }
 
   // All legs of an Instruction should be inspected before before affirming
   const { data: legs } = await counterInstruction.getLegs();

--- a/src/sdk/settlements/transferRestrictions.ts
+++ b/src/sdk/settlements/transferRestrictions.ts
@@ -16,7 +16,9 @@ import { wellKnown } from '~/consts';
 */
 export const transferRestrictions = async (sdk: Polymesh, ticker: string): Promise<void> => {
   const identity = await sdk.getSigningIdentity();
-  assert(identity);
+  if (!identity) {
+    throw new Error('the SDK must have a signing identity');
+  }
 
   const asset = await sdk.assets.getAsset({ ticker });
 


### PR DESCRIPTION
use ts-morph to clean up test functions into examples

This wasn't as good as I thought it would be, but at least offers a write once experience for the most part. First time using AST manipulation and its kind of tricky, that's why I switched the needed null checks from asserts to the standard throw error.

[DA-379](https://polymesh.atlassian.net/browse/DA-379)

[DA-379]: https://polymesh.atlassian.net/browse/DA-379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

The output can be seen here: https://github.com/PolymeshAssociation/polymesh-sdk-examples/pull/52, which isn't much of an improvement imo. 