### PR TITLE
fix: 🐛 Correct assertion on zero asset balance in portfolio

### DIFF
--- a/src/__tests__/rest/portfolios/transfers.ts
+++ b/src/__tests__/rest/portfolios/transfers.ts
@@ -135,14 +135,7 @@ describe('Portfolio Asset Transfers', () => {
     expect(portfolio).toEqual(
       expect.objectContaining({
         name: custodyPortfolioName,
-        assetBalances: [
-          {
-            asset: assetId,
-            free: '0',
-            locked: '0',
-            total: '0',
-          },
-        ],
+        assetBalances: [],
         id: custodyPortfolioId,
         owner: issuer.did,
         custodian: custodian.did,


### PR DESCRIPTION
### Description

In the latest develop changes on core side, when a asset balance reaches zero in a portfolio, that value is removed from `portfolio.portfolioAssetBalances` storage. Here is the core change - https://github.com/PolymeshAssociation/Polymesh/commit/a79a4ae0765937658f82fb122ccec97c01e58b9f#diff-fb1ae7635150b89447e4ab169b054826ada7d83a632fb647bea7f55a323385a7

This fixes the assertion where it was expected to get zero balance for the same when querying the portfolio details. Now it just returns empty array of asset balances

### Breaking Changes

NA

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
